### PR TITLE
fix: 修改本地导出时默认的图片路径

### DIFF
--- a/src/pack/algorithm/maxrects/Exporter.ts
+++ b/src/pack/algorithm/maxrects/Exporter.ts
@@ -33,7 +33,7 @@ export class Exporter {
     const res = { atlasItems: <any>[], version: version, format: 1};
     const imageFile = await this._generatePackedImage(output, packer);
     const item = {
-      "img": `./${path.basename(output)}.png`,
+      "img": `${path.basename(output)}.png`,
       "sprites": <any>[]
     };
     res.atlasItems.push(item);


### PR DESCRIPTION
移除 `./` 与 `../`